### PR TITLE
Reworked hooks to behave in a mutually exclusive manner

### DIFF
--- a/src/Sienar.Blazor/SienarBlazorExtensions.cs
+++ b/src/Sienar.Blazor/SienarBlazorExtensions.cs
@@ -31,7 +31,7 @@ public static class SienarBlazorExtensions
 
 		return self
 			.AddTransient(typeof(IService<>), typeof(SienarService<>))
-			.AddTransient(typeof(IEntityStateValidator<>), typeof(ConcurrencyStampValidatorHook<>))
+			.AddTransient(typeof(IStateValidator<>), typeof(ConcurrencyStampValidatorHook<>))
 			.AddTransient(typeof(IBeforeProcess<>), typeof(ConcurrencyStampUpdateHook<>));
 	}
 

--- a/src/Sienar.BlazorUtils/Extensions/HooksExtensions.cs
+++ b/src/Sienar.BlazorUtils/Extensions/HooksExtensions.cs
@@ -59,7 +59,7 @@ public static class HooksExtensions
 	public static async Task<bool> Run<TEntity>(
 		this IEnumerable<IStateValidator<TEntity>> stateValidators,
 		TEntity entity,
-		bool isAdding,
+		ActionType action,
 		ILogger logger)
 	{
 		try
@@ -67,7 +67,7 @@ public static class HooksExtensions
 			var wasSuccessful = true;
 			foreach (var validator in stateValidators)
 			{
-				if (!await validator.IsValid(entity, isAdding)) wasSuccessful = false;
+				if (await validator.Validate(entity, action) != HookStatus.Success) wasSuccessful = false;
 			}
 
 			return wasSuccessful;

--- a/src/Sienar.BlazorUtils/Extensions/HooksExtensions.cs
+++ b/src/Sienar.BlazorUtils/Extensions/HooksExtensions.cs
@@ -15,13 +15,11 @@ public static class HooksExtensions
 		ActionType action,
 		ILogger logger)
 	{
-		var wasSuccessful = true;
-
 		try
 		{
 			foreach (var beforeHook in beforeHooks)
 			{
-				if (await beforeHook.Handle(entity, action) != HookStatus.Success) wasSuccessful = false;
+				await beforeHook.Handle(entity, action);
 			}
 		}
 		catch (Exception e)
@@ -33,7 +31,7 @@ public static class HooksExtensions
 			return false;
 		}
 
-		return wasSuccessful;
+		return true;
 	}
 
 	public static async Task Run<TEntity>(
@@ -59,7 +57,7 @@ public static class HooksExtensions
 	}
 
 	public static async Task<bool> Run<TEntity>(
-		this IEnumerable<IEntityStateValidator<TEntity>> stateValidators,
+		this IEnumerable<IStateValidator<TEntity>> stateValidators,
 		TEntity entity,
 		bool isAdding,
 		ILogger logger)
@@ -83,7 +81,7 @@ public static class HooksExtensions
 
 	public static async Task<bool> Validate<TEntity>(
 		this IEnumerable<IAccessValidator<TEntity>> accessValidators,
-		TEntity entity,
+		TEntity? entity,
 		ActionType action,
 		ILogger logger)
 	{

--- a/src/Sienar.BlazorUtils/Extensions/HooksExtensions.cs
+++ b/src/Sienar.BlazorUtils/Extensions/HooksExtensions.cs
@@ -56,7 +56,7 @@ public static class HooksExtensions
 		}
 	}
 
-	public static async Task<bool> Run<TEntity>(
+	public static async Task<bool> Validate<TEntity>(
 		this IEnumerable<IStateValidator<TEntity>> stateValidators,
 		TEntity entity,
 		ActionType action,

--- a/src/Sienar.BlazorUtils/Infrastructure/Hooks/ConcurrencyStampUpdateHook.cs
+++ b/src/Sienar.BlazorUtils/Infrastructure/Hooks/ConcurrencyStampUpdateHook.cs
@@ -8,13 +8,13 @@ public class ConcurrencyStampUpdateHook<TEntity> : IBeforeProcess<TEntity>
 	where TEntity : EntityBase
 {
 	/// <inheritdoc />
-	public Task<HookStatus> Handle(TEntity entity, ActionType action)
+	public Task Handle(TEntity entity, ActionType action)
 	{
 		if (action is ActionType.Create or ActionType.Update)
 		{
 			entity.ConcurrencyStamp = Guid.NewGuid();
 		}
 
-		return Task.FromResult(HookStatus.Success);
+		return Task.CompletedTask;
 	}
 }

--- a/src/Sienar.BlazorUtils/Infrastructure/Hooks/ConcurrencyStampValidatorHook.cs
+++ b/src/Sienar.BlazorUtils/Infrastructure/Hooks/ConcurrencyStampValidatorHook.cs
@@ -9,7 +9,7 @@ using Sienar.Infrastructure.Services;
 namespace Sienar.Infrastructure.Hooks;
 
 public class ConcurrencyStampValidatorHook<TEntity>
-	: DbService<TEntity, DbContext>, IEntityStateValidator<TEntity>
+	: DbService<TEntity, DbContext>, IStateValidator<TEntity>
 	where TEntity : EntityBase
 {
 	/// <inheritdoc />
@@ -20,10 +20,10 @@ public class ConcurrencyStampValidatorHook<TEntity>
 		: base(contextAccessor, logger, notifier) {}
 
 	/// <inheritdoc />
-	public async Task<bool> IsValid(TEntity entity, bool adding)
+	public async Task<HookStatus> Validate(TEntity entity, ActionType action)
 	{
-		// Don't run on insert
-		if (adding) return true;
+		// Only run on update
+		if (action is not ActionType.Update) return HookStatus.Success;
 
 		var concurrencyStamp = await EntitySet
 			.Where(m => m.Id == entity.Id)
@@ -34,9 +34,9 @@ public class ConcurrencyStampValidatorHook<TEntity>
 			|| concurrencyStamp != entity.ConcurrencyStamp)
 		{
 			Notifier.Error($"Unable to update {typeof(TEntity).Name}: the entity has been updated by another user.");
-			return false;
+			return HookStatus.Conflict;
 		}
 
-		return true;
+		return HookStatus.Success;
 	}
 }

--- a/src/Sienar.BlazorUtils/Infrastructure/Hooks/IBeforeProcess.cs
+++ b/src/Sienar.BlazorUtils/Infrastructure/Hooks/IBeforeProcess.cs
@@ -5,5 +5,5 @@ namespace Sienar.Infrastructure.Hooks;
 // ReSharper disable once TypeParameterCanBeVariant
 public interface IBeforeProcess<TRequest>
 {
-	Task<HookStatus> Handle(TRequest request, ActionType action);
+	Task Handle(TRequest request, ActionType action);
 }

--- a/src/Sienar.BlazorUtils/Infrastructure/Hooks/IStateValidator.cs
+++ b/src/Sienar.BlazorUtils/Infrastructure/Hooks/IStateValidator.cs
@@ -3,12 +3,12 @@
 namespace Sienar.Infrastructure.Hooks;
 
 // ReSharper disable once TypeParameterCanBeVariant
-public interface IEntityStateValidator<TEntity>
+public interface IStateValidator<TEntity>
 {
 	/// <summary>
 	/// Validates that an entity does not violate logical rules of the app state (for example, checking fields for uniqueness against the database)
 	/// </summary>
 	/// <param name="entity">The entity to validate against the current app state</param>
-	/// <param name="adding">True if the entity is being newly created, else false</param>
-	Task<bool> IsValid(TEntity entity, bool adding);
+	/// <param name="action">The type of action</param>
+	Task<HookStatus> Validate(TEntity entity, ActionType action);
 }

--- a/src/Sienar.BlazorUtils/Infrastructure/Services/EntityDeleter.cs
+++ b/src/Sienar.BlazorUtils/Infrastructure/Services/EntityDeleter.cs
@@ -62,7 +62,7 @@ public class EntityDeleter<TEntity, TContext>
 			return false;
 		}
 
-		if (!await _stateValidators.Run(entity, ActionType.Delete, Logger)
+		if (!await _stateValidators.Validate(entity, ActionType.Delete, Logger)
 			|| !await _beforeHooks.Run(entity, ActionType.Delete, Logger))
 		{
 			Notifier.Error(StatusMessages.Crud<TEntity>.DeleteFailed());

--- a/src/Sienar.BlazorUtils/Infrastructure/Services/EntityDeleter.cs
+++ b/src/Sienar.BlazorUtils/Infrastructure/Services/EntityDeleter.cs
@@ -15,6 +15,7 @@ public class EntityDeleter<TEntity, TContext>
 	where TContext : DbContext
 {
 	private readonly IEnumerable<IAccessValidator<TEntity>> _accessValidators;
+	private readonly IEnumerable<IStateValidator<TEntity>> _stateValidators;
 	private readonly IEnumerable<IBeforeProcess<TEntity>> _beforeHooks;
 	private readonly IEnumerable<IAfterProcess<TEntity>> _afterHooks;
 
@@ -24,11 +25,13 @@ public class EntityDeleter<TEntity, TContext>
 		ILogger<DbService<TEntity, TContext>> logger,
 		INotificationService notifier,
 		IEnumerable<IAccessValidator<TEntity>> accessValidators,
+		IEnumerable<IStateValidator<TEntity>> stateValidators,
 		IEnumerable<IBeforeProcess<TEntity>> beforeHooks,
 		IEnumerable<IAfterProcess<TEntity>> afterHooks)
 		: base(contextAccessor, logger, notifier)
 	{
 		_accessValidators = accessValidators;
+		_stateValidators = stateValidators;
 		_beforeHooks = beforeHooks;
 		_afterHooks = afterHooks;
 	}
@@ -59,7 +62,8 @@ public class EntityDeleter<TEntity, TContext>
 			return false;
 		}
 
-		if (!await _beforeHooks.Run(entity, ActionType.Delete, Logger))
+		if (!await _stateValidators.Run(entity, ActionType.Delete, Logger)
+			|| !await _beforeHooks.Run(entity, ActionType.Delete, Logger))
 		{
 			Notifier.Error(StatusMessages.Crud<TEntity>.DeleteFailed());
 			return false;
@@ -92,6 +96,7 @@ public class EntityDeleter<TEntity> : EntityDeleter<TEntity, DbContext>
 		ILogger<DbService<TEntity, DbContext>> logger,
 		INotificationService notifier,
 		IEnumerable<IAccessValidator<TEntity>> accessValidators,
+		IEnumerable<IStateValidator<TEntity>> stateValidators,
 		IEnumerable<IBeforeProcess<TEntity>> beforeHooks,
 		IEnumerable<IAfterProcess<TEntity>> afterHooks)
 		: base(
@@ -99,6 +104,7 @@ public class EntityDeleter<TEntity> : EntityDeleter<TEntity, DbContext>
 			logger,
 			notifier,
 			accessValidators,
+			stateValidators,
 			beforeHooks,
 			afterHooks) {}
 }

--- a/src/Sienar.BlazorUtils/Infrastructure/Services/EntityWriter.cs
+++ b/src/Sienar.BlazorUtils/Infrastructure/Services/EntityWriter.cs
@@ -44,7 +44,7 @@ public class EntityWriter<TEntity, TContext> : DbService<TEntity, TContext>, IEn
 			return Guid.Empty;
 		}
 
-		if (!await _stateValidators.Run(model, ActionType.Create, Logger)
+		if (!await _stateValidators.Validate(model, ActionType.Create, Logger)
 		|| !await _beforeHooks.Run(model, ActionType.Create, Logger))
 		{
 			Notifier.Error(StatusMessages.Crud<TEntity>.CreateFailed());
@@ -77,7 +77,7 @@ public class EntityWriter<TEntity, TContext> : DbService<TEntity, TContext>, IEn
 			return false;
 		}
 
-		if (!await _stateValidators.Run(model, ActionType.Update, Logger)
+		if (!await _stateValidators.Validate(model, ActionType.Update, Logger)
 		|| !await _beforeHooks.Run(model, ActionType.Update, Logger))
 		{
 			Notifier.Error(StatusMessages.Crud<TEntity>.UpdateFailed());

--- a/src/Sienar.BlazorUtils/Infrastructure/Services/EntityWriter.cs
+++ b/src/Sienar.BlazorUtils/Infrastructure/Services/EntityWriter.cs
@@ -14,7 +14,7 @@ public class EntityWriter<TEntity, TContext> : DbService<TEntity, TContext>, IEn
 	where TContext : DbContext
 {
 	private readonly IEnumerable<IAccessValidator<TEntity>> _accessValidators;
-	private readonly IEnumerable<IEntityStateValidator<TEntity>> _stateValidators;
+	private readonly IEnumerable<IStateValidator<TEntity>> _stateValidators;
 	private readonly IEnumerable<IBeforeProcess<TEntity>> _beforeHooks;
 	private readonly IEnumerable<IAfterProcess<TEntity>> _afterHooks;
 
@@ -24,7 +24,7 @@ public class EntityWriter<TEntity, TContext> : DbService<TEntity, TContext>, IEn
 		ILogger<DbService<TEntity, TContext>> logger,
 		INotificationService notifier,
 		IEnumerable<IAccessValidator<TEntity>> accessValidators,
-		IEnumerable<IEntityStateValidator<TEntity>> stateValidators,
+		IEnumerable<IStateValidator<TEntity>> stateValidators,
 		IEnumerable<IBeforeProcess<TEntity>> beforeHooks,
 		IEnumerable<IAfterProcess<TEntity>> afterHooks)
 		: base(contextAccessor, logger, notifier)
@@ -44,7 +44,7 @@ public class EntityWriter<TEntity, TContext> : DbService<TEntity, TContext>, IEn
 			return Guid.Empty;
 		}
 
-		if (!await _stateValidators.Run(model, true, Logger)
+		if (!await _stateValidators.Run(model, ActionType.Create, Logger)
 		|| !await _beforeHooks.Run(model, ActionType.Create, Logger))
 		{
 			Notifier.Error(StatusMessages.Crud<TEntity>.CreateFailed());
@@ -77,7 +77,7 @@ public class EntityWriter<TEntity, TContext> : DbService<TEntity, TContext>, IEn
 			return false;
 		}
 
-		if (!await _stateValidators.Run(model, false, Logger)
+		if (!await _stateValidators.Run(model, ActionType.Update, Logger)
 		|| !await _beforeHooks.Run(model, ActionType.Update, Logger))
 		{
 			Notifier.Error(StatusMessages.Crud<TEntity>.UpdateFailed());
@@ -111,7 +111,7 @@ public class EntityWriter<TEntity> : EntityWriter<TEntity, DbContext>
 		ILogger<DbService<TEntity, DbContext>> logger,
 		INotificationService notifier,
 		IEnumerable<IAccessValidator<TEntity>> accessValidators,
-		IEnumerable<IEntityStateValidator<TEntity>> stateValidators,
+		IEnumerable<IStateValidator<TEntity>> stateValidators,
 		IEnumerable<IBeforeProcess<TEntity>> beforeHooks,
 		IEnumerable<IAfterProcess<TEntity>> afterHooks)
 		: base(

--- a/src/Sienar.BlazorUtils/Infrastructure/Services/ResultService.cs
+++ b/src/Sienar.BlazorUtils/Infrastructure/Services/ResultService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Sienar.Extensions;
 using Sienar.Infrastructure.Hooks;
 using Sienar.Infrastructure.Processors;
 
@@ -30,7 +31,7 @@ public class ResultService<TResult> : IResultService<TResult>
 	{
 		TResult? result = default;
 
-		if (!await ValidateAccess(result))
+		if (!await _accessValidators.Validate(result, ActionType.ResultAction, _logger))
 		{
 			_processor.NotifyNoPermission();
 			return result;
@@ -49,55 +50,10 @@ public class ResultService<TResult> : IResultService<TResult>
 			return result;
 		}
 
-		if (!await RunAfterHooks(result!))
-		{
-			return default;
-		}
+		if (result == null) return default;
+		await _afterHooks.Run(result, ActionType.ResultAction, _logger);
 
 		_processor.NotifySuccess();
 		return result;
-	}
-
-	private async Task<bool> ValidateAccess(TResult? result)
-	{
-		var context = new AccessValidationContext();
-		var anyValidators = false;
-
-		try
-		{
-			foreach (var validator in _accessValidators)
-			{
-				anyValidators = true;
-				await validator.Validate(
-					context,
-					ActionType.ResultAction,
-					result);
-			}
-		}
-		catch (Exception e)
-		{
-			_logger.LogError(e, "One or more access validators failed to run");
-			return false;
-		}
-
-		return !anyValidators || context.CanAccess;
-	}
-
-	private async Task<bool> RunAfterHooks(TResult result)
-	{
-		try
-		{
-			foreach (var hook in _afterHooks)
-			{
-				await hook.Handle(result, ActionType.ResultAction);
-			}
-		}
-		catch (Exception e)
-		{
-			_logger.LogError(e, "One or more after hooks failed to run");
-			return false;
-		}
-
-		return true;
 	}
 }

--- a/src/Sienar.BlazorUtils/Infrastructure/Services/Service.cs
+++ b/src/Sienar.BlazorUtils/Infrastructure/Services/Service.cs
@@ -12,6 +12,7 @@ public class Service<TRequest> : IService<TRequest>
 {
 	private readonly ILogger<Service<TRequest>> _logger;
 	private readonly IEnumerable<IAccessValidator<TRequest>> _accessValidators;
+	private readonly IEnumerable<IStateValidator<TRequest>> _stateValidators;
 	private readonly IEnumerable<IBeforeProcess<TRequest>> _beforeHooks;
 	private readonly IEnumerable<IAfterProcess<TRequest>> _afterHooks;
 	private readonly IProcessor<TRequest> _processor;
@@ -19,12 +20,14 @@ public class Service<TRequest> : IService<TRequest>
 	public Service(
 		ILogger<Service<TRequest>> logger,
 		IEnumerable<IAccessValidator<TRequest>> accessValidators,
+		IEnumerable<IStateValidator<TRequest>> stateValidators,
 		IEnumerable<IBeforeProcess<TRequest>> beforeHooks,
 		IEnumerable<IAfterProcess<TRequest>> afterHooks,
 		IProcessor<TRequest> processor)
 	{
 		_logger = logger;
 		_accessValidators = accessValidators;
+		_stateValidators = stateValidators;
 		_beforeHooks = beforeHooks;
 		_afterHooks = afterHooks;
 		_processor = processor;
@@ -36,6 +39,12 @@ public class Service<TRequest> : IService<TRequest>
 		if (!await _accessValidators.Validate(request, ActionType.Action, _logger))
 		{
 			_processor.NotifyNoPermission();
+			return false;
+		}
+
+		if (!await _stateValidators.Run(request, ActionType.Action, _logger))
+		{
+			_processor.NotifyFailure();
 			return false;
 		}
 

--- a/src/Sienar.BlazorUtils/Infrastructure/Services/Service.cs
+++ b/src/Sienar.BlazorUtils/Infrastructure/Services/Service.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Sienar.Extensions;
 using Sienar.Infrastructure.Hooks;
 using Sienar.Infrastructure.Processors;
 
@@ -32,13 +33,13 @@ public class Service<TRequest> : IService<TRequest>
 	/// <inheritdoc />
 	public virtual async Task<bool> Execute(TRequest request)
 	{
-		if (!await ValidateAccess(request))
+		if (!await _accessValidators.Validate(request, ActionType.Action, _logger))
 		{
 			_processor.NotifyNoPermission();
 			return false;
 		}
 
-		if (!await RunBeforeHooks(request))
+		if (!await _beforeHooks.Run(request, ActionType.Action, _logger))
 		{
 			_processor.NotifyFailure();
 			return false;
@@ -62,70 +63,9 @@ public class Service<TRequest> : IService<TRequest>
 			return false;
 		}
 
-		await RunAfterHooks(request);
+		await _afterHooks.Run(request, ActionType.Action, _logger);
 
 		_processor.NotifySuccess();
 		return true;
-	}
-
-	private async Task<bool> ValidateAccess(TRequest request)
-	{
-		var context = new AccessValidationContext();
-		var anyValidators = false;
-
-		try
-		{
-			foreach (var validator in _accessValidators)
-			{
-				anyValidators = true;
-				await validator.Validate(
-					context,
-					ActionType.Action,
-					request);
-			}
-		}
-		catch (Exception e)
-		{
-			_logger.LogError(e, "One or more access validators failed to run");
-			return false;
-		}
-
-		return !anyValidators || context.CanAccess;
-	}
-
-	private async Task<bool> RunBeforeHooks(TRequest model)
-	{
-		var successful = true;
-
-		try
-		{
-			foreach (var hook in _beforeHooks)
-			{
-				if (await hook.Handle(model, ActionType.Action) != HookStatus.Success)
-					successful = false;
-			}
-		}
-		catch (Exception e)
-		{
-			_logger.LogError(e, "One or more before hooks failed to run");
-			successful = false;
-		}
-
-		return successful;
-	}
-
-	private async Task RunAfterHooks(TRequest model)
-	{
-		try
-		{
-			foreach (var hook in _afterHooks)
-			{
-				await hook.Handle(model, ActionType.Action);
-			}
-		}
-		catch (Exception e)
-		{
-			_logger.LogError(e, "One or more after hooks failed to run");
-		}
 	}
 }

--- a/src/Sienar.BlazorUtils/Infrastructure/Services/Service.cs
+++ b/src/Sienar.BlazorUtils/Infrastructure/Services/Service.cs
@@ -42,7 +42,7 @@ public class Service<TRequest> : IService<TRequest>
 			return false;
 		}
 
-		if (!await _stateValidators.Run(request, ActionType.Action, _logger))
+		if (!await _stateValidators.Validate(request, ActionType.Action, _logger))
 		{
 			_processor.NotifyFailure();
 			return false;

--- a/src/Sienar.Cms/Identity/Hooks/AcceptTosHook.cs
+++ b/src/Sienar.Cms/Identity/Hooks/AcceptTosHook.cs
@@ -6,7 +6,7 @@ using Sienar.Infrastructure.Hooks;
 
 namespace Sienar.Identity.Hooks;
 
-public class AcceptTosHook : IBeforeProcess<RegisterRequest>
+public class AcceptTosHook : IStateValidator<RegisterRequest>
 {
 	private readonly INotificationService _notifier;
 
@@ -16,7 +16,7 @@ public class AcceptTosHook : IBeforeProcess<RegisterRequest>
 	}
 
 	/// <inheritdoc />
-	public Task<HookStatus> Handle(RegisterRequest request, ActionType action)
+	public Task<HookStatus> Validate(RegisterRequest request, ActionType action)
 	{
 		if (!request.AcceptTos)
 		{

--- a/src/Sienar.Cms/Identity/Hooks/EnsureAccountInfoUniqueHook.cs
+++ b/src/Sienar.Cms/Identity/Hooks/EnsureAccountInfoUniqueHook.cs
@@ -11,8 +11,8 @@ using Sienar.Infrastructure.Services;
 namespace Sienar.Identity.Hooks;
 
 public class EnsureAccountInfoUniqueHook : DbService<SienarUser>,
-	IEntityStateValidator<SienarUser>,
-	IBeforeProcess<RegisterRequest>
+	IStateValidator<SienarUser>,
+	IStateValidator<RegisterRequest>
 {
 	/// <inheritdoc />
 	public EnsureAccountInfoUniqueHook(
@@ -22,7 +22,7 @@ public class EnsureAccountInfoUniqueHook : DbService<SienarUser>,
 		: base(contextAccessor, logger, notifier) {}
 
 	/// <inheritdoc />
-	Task<bool> IEntityStateValidator<SienarUser>.IsValid(SienarUser entity, bool adding)
+	Task<HookStatus> IStateValidator<SienarUser>.Validate(SienarUser entity, ActionType type)
 		=> UserIsUnique(
 			entity.Username,
 			entity.Email,
@@ -30,18 +30,14 @@ public class EnsureAccountInfoUniqueHook : DbService<SienarUser>,
 			entity.Id);
 
 	/// <inheritdoc />
-	async Task<HookStatus> IBeforeProcess<RegisterRequest>.Handle(
+	Task<HookStatus> IStateValidator<RegisterRequest>.Validate(
 		RegisterRequest request,
 		ActionType action)
-	{
-		return await UserIsUnique(
+		=> UserIsUnique(
 			request.Username,
-			request.Email)
-			? HookStatus.Success
-			: HookStatus.Conflict;
-	}
+			request.Email);
 
-	private async Task<bool> UserIsUnique(
+	private async Task<HookStatus> UserIsUnique(
 		string username,
 		string email,
 		string? pendingEmail = null,
@@ -80,6 +76,8 @@ public class EnsureAccountInfoUniqueHook : DbService<SienarUser>,
 			valid = false;
 		}
 
-		return valid;
+		return valid
+			? HookStatus.Success
+			: HookStatus.Conflict;
 	}
 }

--- a/src/Sienar.Cms/Identity/Hooks/RegistrationOpenHook.cs
+++ b/src/Sienar.Cms/Identity/Hooks/RegistrationOpenHook.cs
@@ -8,7 +8,7 @@ using Sienar.Infrastructure.Hooks;
 
 namespace Sienar.Identity.Hooks;
 
-public class RegistrationOpenHook : IBeforeProcess<RegisterRequest>
+public class RegistrationOpenHook : IStateValidator<RegisterRequest>
 {
 	private readonly SienarOptions _sienarOptions;
 	private readonly INotificationService _notifier;
@@ -22,7 +22,7 @@ public class RegistrationOpenHook : IBeforeProcess<RegisterRequest>
 	}
 
 	/// <inheritdoc />
-	public Task<HookStatus> Handle(RegisterRequest request, ActionType action)
+	public Task<HookStatus> Validate(RegisterRequest request, ActionType action)
 	{
 		if (!_sienarOptions.RegistrationOpen)
 		{

--- a/src/Sienar.Cms/Identity/Hooks/RemoveUserRelatedEntitiesHook.cs
+++ b/src/Sienar.Cms/Identity/Hooks/RemoveUserRelatedEntitiesHook.cs
@@ -33,39 +33,28 @@ public class RemoveUserRelatedEntitiesHook : DbService<SienarUser>,
 	}
 
 	/// <inheritdoc />
-	async Task<HookStatus> IBeforeProcess<SienarUser>.Handle(
+	Task IBeforeProcess<SienarUser>.Handle(
 		SienarUser entity,
 		ActionType action)
 	{
-		if (action != ActionType.Delete) return HookStatus.Success;
-		return await HandleCore(entity);
+		return action == ActionType.Delete
+			? HandleCore(entity)
+			: Task.CompletedTask;
 	}
 
 	/// <inheritdoc />
-	async Task<HookStatus> IBeforeProcess<DeleteAccountRequest>.Handle(
+	async Task IBeforeProcess<DeleteAccountRequest>.Handle(
 		DeleteAccountRequest request,
 		ActionType action)
 	{
-		if (action != ActionType.Action) return HookStatus.Success;
+		if (action != ActionType.Action) return;
 
-		var userId = _userAccessor.GetUserId();
-		if (!userId.HasValue)
-		{
-			Notifier.Error(ErrorMessages.Account.LoginRequired);
-			return HookStatus.Unauthorized;
-		}
-
-		var user = await EntitySet.FindAsync(userId.Value);
-		if (user is null)
-		{
-			Notifier.Error(ErrorMessages.Account.LoginRequired);
-			return HookStatus.Unauthorized;
-		}
-
-		return await HandleCore(user);
+		var userId = _userAccessor.GetUserId()!;
+		var user = (await EntitySet.FindAsync(userId.Value))!;
+		await HandleCore(user);
 	}
 
-	private async Task<HookStatus> HandleCore(SienarUser entity)
+	private async Task HandleCore(SienarUser entity)
 	{
 		await Context
 			.Entry(entity)
@@ -101,7 +90,5 @@ public class RemoveUserRelatedEntitiesHook : DbService<SienarUser>,
 
 		EntitySet.Update(entity);
 		await Context.SaveChangesAsync();
-
-		return HookStatus.Success;
 	}
 }

--- a/src/Sienar.Cms/Identity/Hooks/UserPasswordUpdateHook.cs
+++ b/src/Sienar.Cms/Identity/Hooks/UserPasswordUpdateHook.cs
@@ -14,10 +14,9 @@ public class UserPasswordUpdateHook : IBeforeProcess<SienarUser>
 	}
 
 	/// <inheritdoc />
-	public Task<HookStatus> Handle(SienarUser user, ActionType action)
+	public Task Handle(SienarUser user, ActionType action)
 	{
-		var success = Task.FromResult(HookStatus.Success);
-		if (action is not (ActionType.Create or ActionType.Update)) return success;
+		if (action is not (ActionType.Create or ActionType.Update)) return Task.CompletedTask;
 
 		if (user.Password != SienarConstants.PasswordPlaceholder)
 		{
@@ -26,6 +25,6 @@ public class UserPasswordUpdateHook : IBeforeProcess<SienarUser>
 				user.Password);
 		}
 
-		return success;
+		return Task.CompletedTask;
 	}
 }

--- a/src/Sienar.Cms/Media/Hooks/AssignMediaFieldsHook.cs
+++ b/src/Sienar.Cms/Media/Hooks/AssignMediaFieldsHook.cs
@@ -15,12 +15,10 @@ public class AssignMediaFieldsHook : IBeforeProcess<Upload>
 	}
 
 	/// <inheritdoc />
-	public Task<HookStatus> Handle(Upload entity, ActionType action)
+	public Task Handle(Upload entity, ActionType action)
 	{
-		var success = Task.FromResult(HookStatus.Success);
-
 		// Only assign fields on create
-		if (action != ActionType.Create) return success;
+		if (action != ActionType.Create) return Task.CompletedTask;
 
 		if (!_userAccessor.UserInRole(Roles.Admin))
 		{
@@ -29,6 +27,6 @@ public class AssignMediaFieldsHook : IBeforeProcess<Upload>
 
 		entity.UploadedAt = DateTime.Now;
 
-		return success;
+		return Task.CompletedTask;
 	}
 }

--- a/src/Sienar.Cms/Media/Hooks/UploadFileHook.cs
+++ b/src/Sienar.Cms/Media/Hooks/UploadFileHook.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Sienar.Infrastructure;
 using Sienar.Infrastructure.Hooks;
 
 namespace Sienar.Media.Hooks;
@@ -9,19 +10,22 @@ public class UploadFileHook : IBeforeProcess<Upload>
 {
 	private readonly IMediaManager _mediaManager;
 	private readonly ILogger<UploadFileHook> _logger;
+	private readonly INotificationService _notifier;
 	public UploadFileHook(
 		IMediaManager mediaManager,
-		ILogger<UploadFileHook> logger)
+		ILogger<UploadFileHook> logger,
+		INotificationService notifier)
 	{
 		_mediaManager = mediaManager;
 		_logger = logger;
+		_notifier = notifier;
 	}
 
 	/// <inheritdoc />
-	public async Task<HookStatus> Handle(Upload entity, ActionType action)
+	public async Task Handle(Upload entity, ActionType action)
 	{
 		// Only upload on create
-		if (action != ActionType.Create) return HookStatus.Success;
+		if (action != ActionType.Create) return;
 
 		entity.Path = _mediaManager.GetFilename(
 			".txt", // TODO: find the actual file extension somehow 
@@ -34,9 +38,7 @@ public class UploadFileHook : IBeforeProcess<Upload>
 		catch (Exception e)
 		{
 			_logger.LogError(e, "Failed to write media file");
-			return HookStatus.Unknown;
+			_notifier.Error("Failed to write media file");
 		}
-
-		return HookStatus.Success;
 	}
 }

--- a/src/Sienar.Cms/SienarCmsExtensions.cs
+++ b/src/Sienar.Cms/SienarCmsExtensions.cs
@@ -34,7 +34,7 @@ public static class SienarCmsExtensions
 			// .AddTransient<IBeforeRead<SienarUser>, IncludeRolesInFilterHook>()
 			.AddTransient<IAccessValidator<SienarUser>, UserIsAdminAccessValidator<SienarUser>>()
 			.AddTransient<IBeforeProcess<SienarUser>, UserPasswordUpdateHook>()
-			.AddTransient<IEntityStateValidator<SienarUser>, EnsureAccountInfoUniqueHook>()
+			.AddTransient<IStateValidator<SienarUser>, EnsureAccountInfoUniqueHook>()
 			.AddTransient<IBeforeProcess<SienarUser>, RemoveUserRelatedEntitiesHook>()
 			.AddTransient<IAfterProcess<SienarUser>, ForceDeletedAccountLogoutHook>();
 
@@ -60,9 +60,9 @@ public static class SienarCmsExtensions
 
 		// Registration
 		self
-			.AddTransient<IBeforeProcess<RegisterRequest>, RegistrationOpenHook>()
-			.AddTransient<IBeforeProcess<RegisterRequest>, AcceptTosHook>()
-			.AddTransient<IBeforeProcess<RegisterRequest>, EnsureAccountInfoUniqueHook>()
+			.AddTransient<IStateValidator<RegisterRequest>, RegistrationOpenHook>()
+			.AddTransient<IStateValidator<RegisterRequest>, AcceptTosHook>()
+			.AddTransient<IStateValidator<RegisterRequest>, EnsureAccountInfoUniqueHook>()
 			.AddTransient<IProcessor<RegisterRequest>, RegisterProcessor>()
 
 			// Email

--- a/src/Sienar.Core/Infrastructure/Services/SienarService.cs
+++ b/src/Sienar.Core/Infrastructure/Services/SienarService.cs
@@ -15,6 +15,7 @@ public class SienarService<TRequest> : Service<TRequest>
 	public SienarService(
 		ILogger<Service<TRequest>> logger,
 		IEnumerable<IAccessValidator<TRequest>> accessValidators,
+		IEnumerable<IStateValidator<TRequest>> stateValidators,
 		IEnumerable<IBeforeProcess<TRequest>> beforeHooks,
 		IEnumerable<IAfterProcess<TRequest>> afterHooks,
 		IProcessor<TRequest> processor,
@@ -22,6 +23,7 @@ public class SienarService<TRequest> : Service<TRequest>
 		: base(
 			logger,
 			accessValidators,
+			stateValidators,
 			beforeHooks,
 			afterHooks, 
 			processor)


### PR DESCRIPTION
With this PR, hooks are now mutually exclusive in their behavior:

- `IAccessValidator` uses a validation context to grant access explicitly
- `IStateValidator` uses a `HookStatus` to short-circuit an action
- `IBeforeProcess` and `IAfterProcess` return a `Task`, so they can't directly be used to do anything

closes #41